### PR TITLE
feat: Virtual Thread 기반 Load Test 엔진 구현 및 성능 지표 집계/결과 저장, 단위 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'com.project'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21' // Virtual Threads 사용을 위해 21 권장
+    sourceCompatibility = '21' // Recommended for virtual threads
 }
 
 configurations {
@@ -22,21 +22,22 @@ repositories {
 }
 
 dependencies {
-    // 1. Web & Central Controller
+    // 1. Web & central controller
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    // 2. Database & Persistence
+    // 2. Database & persistence
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // 3. Performance Metrics (성능 측정을 위한 핵심 라이브러리)
-    implementation 'io.micrometer:micrometer-registry-prometheus' // Prometheus 연동용
-    implementation 'org.springframework.boot:spring-boot-starter-actuator' // 헬스체크 및 메트릭 노출
+    // 3. Performance metrics
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // 4. Utils & Client
+    // 4. Utils & client
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient 사용을 위해 포함
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.hdrhistogram:HdrHistogram:2.2.2' // P99 with fixed memory footprint
 
     // 5. Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/project/config/ClockConfig.java
+++ b/src/main/java/com/project/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock systemClock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/project/repository/LoadTestResultRepository.java
+++ b/src/main/java/com/project/repository/LoadTestResultRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LoadTestResultRepository {
     void insertResult(LoadTestResult result);
+    void updateResult(LoadTestResult result);
     LoadTestResult selectResultByScenarioId(Long scenarioId);
     void deleteResultByScenarioId(Long scenarioId);
 }

--- a/src/main/java/com/project/service/LoadTestService.java
+++ b/src/main/java/com/project/service/LoadTestService.java
@@ -8,6 +8,7 @@ import com.project.service.dto.TestStats;
 import com.project.service.runner.LoadTestRunner;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Service
@@ -16,15 +17,18 @@ public class LoadTestService {
     private final LoadTestRunner loadTestRunner;
     private final LoadTestResultRepository loadTestResultRepository;
     private final LoadTestScenarioRepository loadTestScenarioRepository;
+    private final Clock clock;
 
     public LoadTestService(
             LoadTestRunner loadTestRunner,
             LoadTestResultRepository loadTestResultRepository,
-            LoadTestScenarioRepository loadTestScenarioRepository
+            LoadTestScenarioRepository loadTestScenarioRepository,
+            Clock clock
     ) {
         this.loadTestRunner = loadTestRunner;
         this.loadTestResultRepository = loadTestResultRepository;
         this.loadTestScenarioRepository = loadTestScenarioRepository;
+        this.clock = clock;
     }
 
     public void startTestEngine(LoadTestScenario scenario) {
@@ -34,7 +38,7 @@ public class LoadTestService {
         // 2. 결과 row 선생성 후 생성된 Result ID 확보
         LoadTestResult result = new LoadTestResult();
         result.setScenarioId(scenario.getId());
-        result.setStartedAt(LocalDateTime.now());
+        result.setStartedAt(LocalDateTime.now(clock));
         loadTestResultRepository.insertResult(result);
 
         // 3. 가상 스레드 기반 테스트 실행
@@ -48,7 +52,7 @@ public class LoadTestService {
         result.setMinLatencyMs(stats.minLatencyMs());
         result.setMaxLatencyMs(stats.maxLatencyMs());
         result.setP99LatencyMs(stats.p99LatencyMs());
-        result.setEndedAt(LocalDateTime.now());
+        result.setEndedAt(LocalDateTime.now(clock));
         loadTestResultRepository.updateResult(result);
     }
 }

--- a/src/main/java/com/project/service/LoadTestService.java
+++ b/src/main/java/com/project/service/LoadTestService.java
@@ -1,40 +1,80 @@
 package com.project.service;
 
 import com.project.model.LoadTestFailLog;
+import com.project.model.LoadTestResult;
 import com.project.model.LoadTestScenario;
 import com.project.repository.LoadTestFailLogRepository;
+import com.project.repository.LoadTestResultRepository;
+import com.project.repository.LoadTestScenarioRepository;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Service
 public class LoadTestService {
 
     private final WebClient.Builder webClientBuilder;
     private final LoadTestFailLogRepository loadTestFailLogRepository;
+    private final LoadTestResultRepository loadTestResultRepository;
+    private final LoadTestScenarioRepository loadTestScenarioRepository;
 
-    public LoadTestService(WebClient.Builder webClientBuilder, LoadTestFailLogRepository loadTestFailLogRepository) {
+    public LoadTestService(WebClient.Builder webClientBuilder, LoadTestFailLogRepository loadTestFailLogRepository, LoadTestResultRepository loadTestResultRepository, LoadTestScenarioRepository loadTestScenarioRepository) {
         this.webClientBuilder = webClientBuilder;
         this.loadTestFailLogRepository = loadTestFailLogRepository;
+        this.loadTestResultRepository = loadTestResultRepository;
+        this.loadTestScenarioRepository = loadTestScenarioRepository;
+    }
+
+    public void startTestEngine(LoadTestScenario scenario) {
+
+        // 1. 시나리오 저장 (MyBatis가 scenario 객체에 id를 채워줌)
+        loadTestScenarioRepository.insertScenario(scenario);
+        Long scenarioId = scenario.getId(); // 시나리오 ID 획득
+
+        // 1. 빈 껍데기(초기 결과) 생성 및 저장
+        LoadTestResult result = new LoadTestResult();
+        result.setScenarioId(scenarioId);
+        result.setStartedAt(LocalDateTime.now());
+
+        // DB에 넣으면 MyBatis가 result 객체 안에 자동으로 생성된 ID를 채워줍니다.
+        loadTestResultRepository.insertResult(result);
+        Long resultId = result.getId(); // 드디어 생긴 ID!
+
+        // 2. 실제 테스트 실행 (이 ID를 들고 갑니다)
+        executeLoadTest(scenario, resultId);
+
+        // 3. 테스트 완료 후 최종 업데이트
+        result.setEndedAt(LocalDateTime.now());
+        // result.setTotalSuccess(count...); // 계산된 결과 세팅
+        loadTestResultRepository.updateResult(result);
     }
 
     /**
      * Virtual Threads execute
      * @param scenario
      **/
-    public void executeLoadTest(LoadTestScenario scenario) {
+    public void executeLoadTest(LoadTestScenario scenario, Long resultId) {
+
+        AtomicLong globalOrder = new AtomicLong(0); // 여러 쓰레드 접근시 데이터 유실 발생 가능성 으로 CAS(Compare-And-Swap) 사용
 
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
             for(int i = 0; i < scenario.getVirtualThreadCount(); i++) {
                 executor.submit(() -> {
-                   callRequest(scenario);
+                    long currentOrder = globalOrder.incrementAndGet();
+                   callRequest(scenario, resultId, currentOrder);
                 });
             }
+
+
 
         }
 
@@ -44,7 +84,7 @@ public class LoadTestService {
      * api Request
      * @param scenario
      */
-    public void callRequest(LoadTestScenario scenario) {
+    public void callRequest(LoadTestScenario scenario, long resultId, long currentOrder) {
         
         long startTime = System.currentTimeMillis(); 
         
@@ -54,6 +94,12 @@ public class LoadTestService {
                     .uri(scenario.getTargetUrl())
                     .bodyValue(scenario.getRequestParams())
                     .retrieve()
+                    .onStatus(HttpStatusCode::isError, response ->
+                            Mono.error(new WebClientResponseException(
+                                    response.statusCode().value(), // 상태 코드 숫자 (예: 404)
+                                    "HTTP Error",
+                                    null, null, null))
+                    )
                     .bodyToMono(String.class)
                     .block();
 
@@ -62,10 +108,16 @@ public class LoadTestService {
             // 실패 시 DB에 로그 저장
             LoadTestFailLog failLog = new LoadTestFailLog();
             failLog.setResultId(resultId);             // 부모 결과 ID
-            failLog.setRequestOrder(order);           // 몇 번째 요청이었는지
-            failLog.setErrorMsg(e.getMessage());      // 에러 메시지 (예: Connection Refused)
-            failLog.setRequestTime(LocalDateTime.now()); // 발생 시각
-            failLog.setHttpStatus(500);               // 기본값 500 (필요시 상세 분류 가능)
+            failLog.setRequestOrder(currentOrder);
+            failLog.setErrorMsg(e.getMessage());
+            failLog.setRequestTime(LocalDateTime.now());
+            if (e instanceof WebClientResponseException ex) {
+                // 서버가 응답은 했으나 에러인 경우 (404, 500 등)
+                failLog.setHttpStatus(ex.getStatusCode().value());
+            } else {
+                // 서버 연결 자체가 안 된 경우 (Timeout, Connection Refused 등)
+                failLog.setHttpStatus(0); // 0이나 특정 약속된 코드로 저장
+            }
 
             loadTestFailLogRepository.insertFailLog(failLog); // DB 저장 실행
         }

--- a/src/main/java/com/project/service/LoadTestService.java
+++ b/src/main/java/com/project/service/LoadTestService.java
@@ -1,152 +1,54 @@
 package com.project.service;
 
-import com.project.model.LoadTestFailLog;
 import com.project.model.LoadTestResult;
 import com.project.model.LoadTestScenario;
-import com.project.repository.LoadTestFailLogRepository;
 import com.project.repository.LoadTestResultRepository;
 import com.project.repository.LoadTestScenarioRepository;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatusCode;
+import com.project.service.dto.TestStats;
+import com.project.service.runner.LoadTestRunner;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Service
 public class LoadTestService {
 
-    private final WebClient.Builder webClientBuilder;
-    private final LoadTestFailLogRepository loadTestFailLogRepository;
+    private final LoadTestRunner loadTestRunner;
     private final LoadTestResultRepository loadTestResultRepository;
     private final LoadTestScenarioRepository loadTestScenarioRepository;
 
-    public LoadTestService(WebClient.Builder webClientBuilder, LoadTestFailLogRepository loadTestFailLogRepository, LoadTestResultRepository loadTestResultRepository, LoadTestScenarioRepository loadTestScenarioRepository) {
-        this.webClientBuilder = webClientBuilder;
-        this.loadTestFailLogRepository = loadTestFailLogRepository;
+    public LoadTestService(
+            LoadTestRunner loadTestRunner,
+            LoadTestResultRepository loadTestResultRepository,
+            LoadTestScenarioRepository loadTestScenarioRepository
+    ) {
+        this.loadTestRunner = loadTestRunner;
         this.loadTestResultRepository = loadTestResultRepository;
         this.loadTestScenarioRepository = loadTestScenarioRepository;
     }
 
-    public record TestStats(int success, int fail) {}
-
     public void startTestEngine(LoadTestScenario scenario) {
-
-        // 1. 시나리오ID를 가져오기 위해 시나리오 저장 (Id값 자동 생성)
+        // 1. 시나리오 insert 후 생성된 ID 확보
         loadTestScenarioRepository.insertScenario(scenario);
-        Long scenarioId = scenario.getId(); 
 
-        // 1. ResultID를 가져오기 위해 데이터 생성 및 저장 (Id값 자동 생성)
+        // 2. 결과 row 선생성 후 생성된 Result ID 확보
         LoadTestResult result = new LoadTestResult();
-        result.setScenarioId(scenarioId);
+        result.setScenarioId(scenario.getId());
         result.setStartedAt(LocalDateTime.now());
         loadTestResultRepository.insertResult(result);
-        Long resultId = result.getId();
 
-        // 2. 테스트 실행
-        TestStats stats = executeLoadTest(scenario, result.getId());
+        // 3. 가상 스레드 기반 테스트 실행
+        TestStats stats = loadTestRunner.run(scenario, result.getId());
 
-        // 3. 테스트 완료 후 최종 업데이트
+        // 4. 테스트 완료 후 집계 결과/성능 지표 최종 업데이트
+        result.setSuccessCount(stats.success());
+        result.setFailCount(stats.fail());
+        result.setTotalRequests(stats.totalRequests());
+        result.setAvgLatencyMs(stats.avgLatencyMs());
+        result.setMinLatencyMs(stats.minLatencyMs());
+        result.setMaxLatencyMs(stats.maxLatencyMs());
+        result.setP99LatencyMs(stats.p99LatencyMs());
         result.setEndedAt(LocalDateTime.now());
-        // result.setTotalSuccess(count...); // 계산된 결과 세팅
         loadTestResultRepository.updateResult(result);
     }
-
-    /**
-     * Virtual Threads execute
-     * @param scenario
-     * @return TestStats (성공, 실패 횟수)
-     **/
-    public TestStats executeLoadTest(LoadTestScenario scenario, Long resultId) {
-
-        AtomicLong globalOrder = new AtomicLong(0); // 여러 쓰레드 접근시 데이터 유실 발생 가능성 으로 CAS(Compare-And-Swap) 사용
-        AtomicInteger successCount = new AtomicInteger(0);
-        AtomicInteger failCount = new AtomicInteger(0);
-
-        // 종료시간 = 현재시간 + 지속시간
-        long endTimeMillis = System.currentTimeMillis() + (scenario.getDurationSeconds() * 1000L);
-
-
-        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
-
-            for(int i = 0; i < scenario.getVirtualThreadCount(); i++) {
-                executor.submit(() -> {
-
-                    while (System.currentTimeMillis() < endTimeMillis) {
-                        long currentOrder = globalOrder.incrementAndGet();
-                        boolean isSuccess = callRequest(scenario, resultId, currentOrder);
-
-                        if (isSuccess) {
-                            successCount.incrementAndGet(); // 성공시 +1
-                        } else {
-                            failCount.incrementAndGet(); // 실패시 +1
-                        }
-                    }
-
-
-                });
-
-
-            }
-
-        }
-        return new TestStats(successCount.get(), failCount.get());
-
-    }
-
-    /**
-     * api Request
-     * @param scenario
-     */
-    public boolean callRequest(LoadTestScenario scenario, long resultId, long currentOrder) {
-
-        long startTime = System.currentTimeMillis();
-        boolean isSuccess; // Request 별 성공/실패 유무
-
-        try {
-            webClientBuilder.build()
-                    .method(HttpMethod.valueOf(scenario.getHttpMethod()))
-                    .uri(scenario.getTargetUrl())
-                    .bodyValue(scenario.getRequestParams())
-                    .retrieve()
-                    .onStatus(HttpStatusCode::isError, response ->
-                            Mono.error(new WebClientResponseException(
-                                    response.statusCode().value(), // 상태 코드 숫자 (예: 404)
-                                    "HTTP Error",
-                                    null, null, null))
-                    )
-                    .bodyToMono(String.class)
-                    .block();
-
-            isSuccess = true; // 성공
-            long endTime = System.currentTimeMillis();
-        } catch (Exception e) {
-            // 실패 시 DB에 로그 저장
-            LoadTestFailLog failLog = new LoadTestFailLog();
-            failLog.setResultId(resultId);             // 부모 결과 ID
-            failLog.setRequestOrder(currentOrder);
-            failLog.setErrorMsg(e.getMessage());
-            failLog.setRequestTime(LocalDateTime.now());
-            if (e instanceof WebClientResponseException ex) {
-                // 서버가 응답은 했으나 에러인 경우 (404, 500 등)
-                failLog.setHttpStatus(ex.getStatusCode().value());
-            } else {
-                // 서버 연결 자체가 안 된 경우 (Timeout, Connection Refused 등)
-                failLog.setHttpStatus(0); // 0이나 특정 약속된 코드로 저장
-            }
-
-            isSuccess = false; // 실패
-            loadTestFailLogRepository.insertFailLog(failLog); // DB 저장 실행
-        }
-
-
-        return isSuccess;
-    }
-
 }

--- a/src/main/java/com/project/service/LoadTestService.java
+++ b/src/main/java/com/project/service/LoadTestService.java
@@ -1,0 +1,62 @@
+package com.project.service;
+
+import com.project.model.LoadTestScenario;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+public class LoadTestService {
+
+    private final WebClient.Builder webClientBuilder;
+
+    public LoadTestService(WebClient.Builder webClientBuilder) {
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    /**
+     * Virtual Threads execute
+     * @param scenario
+     **/
+    public void executeLoadTest(LoadTestScenario scenario) {
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+
+            for(int i = 0; i < scenario.getVirtualThreadCount(); i++) {
+                executor.submit(() -> {
+                   callRequest(scenario);
+                });
+            }
+
+        }
+
+    }
+
+    /**
+     * api Request
+     * @param scenario
+     */
+    public void callRequest(LoadTestScenario scenario) {
+        
+        long startTime = System.currentTimeMillis(); 
+        
+        try {
+            webClientBuilder.build()
+                    .method(HttpMethod.valueOf(scenario.getHttpMethod()))
+                    .uri(scenario.getTargetUrl())
+                    .bodyValue(scenario.getRequestParams())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            long endTime = System.currentTimeMillis();
+        } catch (Exception e) {
+            // FailLog 구현
+        }
+        
+    }
+
+}

--- a/src/main/java/com/project/service/client/LoadTestRequestExecutor.java
+++ b/src/main/java/com/project/service/client/LoadTestRequestExecutor.java
@@ -1,0 +1,69 @@
+package com.project.service.client;
+
+import com.project.model.LoadTestFailLog;
+import com.project.model.LoadTestScenario;
+import com.project.repository.LoadTestFailLogRepository;
+import com.project.service.dto.RequestResult;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+@Component
+public class LoadTestRequestExecutor {
+
+    private final WebClient.Builder webClientBuilder;
+    private final LoadTestFailLogRepository loadTestFailLogRepository;
+
+    public LoadTestRequestExecutor(WebClient.Builder webClientBuilder, LoadTestFailLogRepository loadTestFailLogRepository) {
+        this.webClientBuilder = webClientBuilder;
+        this.loadTestFailLogRepository = loadTestFailLogRepository;
+    }
+
+    public RequestResult execute(LoadTestScenario scenario, long resultId, long currentOrder) {
+        long startTime = System.currentTimeMillis();
+        boolean isSuccess;
+
+        try {
+            // 시나리오 설정(메서드/URL/파라미터)으로 실제 HTTP 요청 실행
+            webClientBuilder.build()
+                    .method(HttpMethod.valueOf(scenario.getHttpMethod()))
+                    .uri(scenario.getTargetUrl())
+                    .bodyValue(scenario.getRequestParams())
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, response ->
+                            Mono.error(new WebClientResponseException(
+                                    response.statusCode().value(),
+                                    "HTTP Error",
+                                    null, null, null))
+                    )
+                    .bodyToMono(String.class)
+                    .block();
+            isSuccess = true;
+        } catch (Exception e) {
+            // 실패 요청은 상세 로그(resultId, 순번, 에러메시지, 상태코드)로 저장
+            LoadTestFailLog failLog = new LoadTestFailLog();
+            failLog.setResultId(resultId);
+            failLog.setRequestOrder(currentOrder);
+            failLog.setErrorMsg(e.getMessage());
+            failLog.setRequestTime(LocalDateTime.now());
+
+            if (e instanceof WebClientResponseException ex) {
+                failLog.setHttpStatus(ex.getStatusCode().value());
+            } else {
+                failLog.setHttpStatus(0);
+            }
+
+            loadTestFailLogRepository.insertFailLog(failLog);
+            isSuccess = false;
+        }
+
+        // 요청 지연시간(ms) 측정값과 성공 여부를 함께 반환
+        long latencyMs = System.currentTimeMillis() - startTime;
+        return new RequestResult(isSuccess, latencyMs);
+    }
+}

--- a/src/main/java/com/project/service/dto/RequestResult.java
+++ b/src/main/java/com/project/service/dto/RequestResult.java
@@ -1,0 +1,4 @@
+package com.project.service.dto;
+
+public record RequestResult(boolean success, long latencyMs) {
+}

--- a/src/main/java/com/project/service/dto/TestStats.java
+++ b/src/main/java/com/project/service/dto/TestStats.java
@@ -1,0 +1,12 @@
+package com.project.service.dto;
+
+public record TestStats(
+        int success,
+        int fail,
+        int totalRequests,
+        double avgLatencyMs,
+        double minLatencyMs,
+        double maxLatencyMs,
+        double p99LatencyMs
+) {
+}

--- a/src/main/java/com/project/service/metrics/LoadTestMetricsCollector.java
+++ b/src/main/java/com/project/service/metrics/LoadTestMetricsCollector.java
@@ -1,0 +1,73 @@
+package com.project.service.metrics;
+
+import com.project.service.dto.TestStats;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+
+public class LoadTestMetricsCollector {
+
+    // 요청 결과 집계값
+    private final AtomicInteger successCount = new AtomicInteger(0);
+    private final AtomicInteger failCount = new AtomicInteger(0);
+
+    // latency 집계용 누적기
+    private final LongAdder latencySum = new LongAdder();
+    private final LongAccumulator minLatency = new LongAccumulator(Long::min, Long.MAX_VALUE);
+    private final LongAccumulator maxLatency = new LongAccumulator(Long::max, 0L);
+
+    // P99 계산을 위해 요청별 latency 원본 보관
+    private final List<Long> latencies = Collections.synchronizedList(new ArrayList<>());
+
+    public void recordSuccess(long latencyMs) {
+        successCount.incrementAndGet();
+        recordLatency(latencyMs);
+    }
+
+    public void recordFailure(long latencyMs) {
+        failCount.incrementAndGet();
+        recordLatency(latencyMs);
+    }
+
+    public TestStats toStats() {
+        int success = successCount.get();
+        int fail = failCount.get();
+        int totalRequests = success + fail;
+
+        // 요청이 한 건도 없으면 0으로 초기화된 통계 반환
+        if (totalRequests == 0) {
+            return new TestStats(0, 0, 0, 0.0, 0.0, 0.0, 0.0);
+        }
+
+        double avgLatencyMs = (double) latencySum.sum() / totalRequests;
+        double minLatencyMs = (double) minLatency.get();
+        double maxLatencyMs = (double) maxLatency.get();
+        double p99LatencyMs = calculateP99(latencies);
+
+        return new TestStats(success, fail, totalRequests, avgLatencyMs, minLatencyMs, maxLatencyMs, p99LatencyMs);
+    }
+
+    private void recordLatency(long latencyMs) {
+        latencySum.add(latencyMs);
+        minLatency.accumulate(latencyMs);
+        maxLatency.accumulate(latencyMs);
+        latencies.add(latencyMs);
+    }
+
+    private double calculateP99(List<Long> latencyValues) {
+        if (latencyValues.isEmpty()) {
+            return 0.0;
+        }
+
+        // 오름차순 정렬 후 99% 지점 인덱스를 선택
+        List<Long> sorted = new ArrayList<>(latencyValues);
+        Collections.sort(sorted);
+        int index = (int) Math.ceil(sorted.size() * 0.99) - 1;
+        index = Math.max(index, 0);
+        return sorted.get(index);
+    }
+}

--- a/src/main/java/com/project/service/metrics/LoadTestMetricsCollector.java
+++ b/src/main/java/com/project/service/metrics/LoadTestMetricsCollector.java
@@ -1,27 +1,33 @@
 package com.project.service.metrics;
 
 import com.project.service.dto.TestStats;
+import org.HdrHistogram.AtomicHistogram;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
 public class LoadTestMetricsCollector {
 
-    // 요청 결과 집계값
+    // 요청 결과 카운터
     private final AtomicInteger successCount = new AtomicInteger(0);
     private final AtomicInteger failCount = new AtomicInteger(0);
 
-    // latency 집계용 누적기
+    // 지연시간 집계값
     private final LongAdder latencySum = new LongAdder();
     private final LongAccumulator minLatency = new LongAccumulator(Long::min, Long.MAX_VALUE);
     private final LongAccumulator maxLatency = new LongAccumulator(Long::max, 0L);
 
-    // P99 계산을 위해 요청별 latency 원본 보관
-    private final List<Long> latencies = Collections.synchronizedList(new ArrayList<>());
+    private static final long MAX_TRACKABLE_LATENCY_MS = 3_600_000L; // 1시간
+    private final AtomicHistogram latencyHistogram = new AtomicHistogram(MAX_TRACKABLE_LATENCY_MS, 3);
+
+    /*
+     * 기존 방식:
+     * 모든 latency를 List에 저장한 뒤 정렬해서 P99를 계산했습니다.
+     * 이 방식은 요청 수가 늘어날수록 메모리가 선형 증가하여 고부하에서 OOM 위험이 있습니다.
+     *
+     * private final List<Long> latencies = Collections.synchronizedList(new ArrayList<>());
+     */
 
     public void recordSuccess(long latencyMs) {
         successCount.incrementAndGet();
@@ -38,7 +44,6 @@ public class LoadTestMetricsCollector {
         int fail = failCount.get();
         int totalRequests = success + fail;
 
-        // 요청이 한 건도 없으면 0으로 초기화된 통계 반환
         if (totalRequests == 0) {
             return new TestStats(0, 0, 0, 0.0, 0.0, 0.0, 0.0);
         }
@@ -46,28 +51,36 @@ public class LoadTestMetricsCollector {
         double avgLatencyMs = (double) latencySum.sum() / totalRequests;
         double minLatencyMs = (double) minLatency.get();
         double maxLatencyMs = (double) maxLatency.get();
-        double p99LatencyMs = calculateP99(latencies);
+        double p99LatencyMs = latencyHistogram.getValueAtPercentile(99.0);
 
         return new TestStats(success, fail, totalRequests, avgLatencyMs, minLatencyMs, maxLatencyMs, p99LatencyMs);
     }
 
     private void recordLatency(long latencyMs) {
-        latencySum.add(latencyMs);
-        minLatency.accumulate(latencyMs);
-        maxLatency.accumulate(latencyMs);
-        latencies.add(latencyMs);
+        long boundedLatencyMs = Math.max(0L, Math.min(latencyMs, MAX_TRACKABLE_LATENCY_MS));
+
+        latencySum.add(boundedLatencyMs);
+        minLatency.accumulate(boundedLatencyMs);
+        maxLatency.accumulate(boundedLatencyMs);
+        latencyHistogram.recordValue(boundedLatencyMs);
+
+        /*
+         * 기존 방식:
+         * latencies.add(latencyMs);
+         */
     }
 
-    private double calculateP99(List<Long> latencyValues) {
-        if (latencyValues.isEmpty()) {
-            return 0.0;
-        }
-
-        // 오름차순 정렬 후 99% 지점 인덱스를 선택
-        List<Long> sorted = new ArrayList<>(latencyValues);
-        Collections.sort(sorted);
-        int index = (int) Math.ceil(sorted.size() * 0.99) - 1;
-        index = Math.max(index, 0);
-        return sorted.get(index);
-    }
+    /*
+     * 기존 방식:
+     * private double calculateP99(List<Long> latencyValues) {
+     *     if (latencyValues.isEmpty()) {
+     *         return 0.0;
+     *     }
+     *     List<Long> sorted = new ArrayList<>(latencyValues);
+     *     Collections.sort(sorted);
+     *     int index = (int) Math.ceil(sorted.size() * 0.99) - 1;
+     *     index = Math.max(index, 0);
+     *     return sorted.get(index);
+     * }
+     */
 }

--- a/src/main/java/com/project/service/runner/LoadTestRunner.java
+++ b/src/main/java/com/project/service/runner/LoadTestRunner.java
@@ -1,0 +1,55 @@
+package com.project.service.runner;
+
+import com.project.model.LoadTestScenario;
+import com.project.service.client.LoadTestRequestExecutor;
+import com.project.service.dto.RequestResult;
+import com.project.service.dto.TestStats;
+import com.project.service.metrics.LoadTestMetricsCollector;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class LoadTestRunner {
+
+    private final LoadTestRequestExecutor requestExecutor;
+
+    public LoadTestRunner(LoadTestRequestExecutor requestExecutor) {
+        this.requestExecutor = requestExecutor;
+    }
+
+    public TestStats run(LoadTestScenario scenario, long resultId) {
+        // 모든 스레드가 공유하는 글로벌 요청 순번
+        AtomicLong globalOrder = new AtomicLong(0);
+        // 성공/실패 카운트 + latency 통계를 누적하는 집계기
+        LoadTestMetricsCollector metricsCollector = new LoadTestMetricsCollector();
+
+        // 종료시각 = 현재시각 + 테스트 지속시간(초)
+        long endTimeMillis = System.currentTimeMillis() + (scenario.getDurationSeconds() * 1000L);
+
+        // Virtual Thread Worker 개수만큼 태스크 생성
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < scenario.getVirtualThreadCount(); i++) {
+                executor.submit(() -> {
+                    // 종료시각 전까지 요청 반복 실행
+                    while (System.currentTimeMillis() < endTimeMillis) {
+                        long currentOrder = globalOrder.incrementAndGet();
+                        RequestResult requestResult = requestExecutor.execute(scenario, resultId, currentOrder);
+
+                        // 요청 결과를 성공/실패 + latency로 집계
+                        if (requestResult.success()) {
+                            metricsCollector.recordSuccess(requestResult.latencyMs());
+                        } else {
+                            metricsCollector.recordFailure(requestResult.latencyMs());
+                        }
+                    }
+                });
+            }
+        }
+
+        // 누적된 집계를 최종 통계 객체로 변환
+        return metricsCollector.toStats();
+    }
+}

--- a/src/main/resources/com/project/repository/LoadTestResultRepository.xml
+++ b/src/main/resources/com/project/repository/LoadTestResultRepository.xml
@@ -29,6 +29,11 @@
         )
     </insert>
 
+    <update id="updateResult">
+        UPDATE load_test_result SET
+
+    </update>
+
     <select id="selectResultByScenarioId" resultType="com.project.model.LoadTestResult">
         SELECT id
              , scenario_id AS scenarioId

--- a/src/main/resources/com/project/repository/LoadTestResultRepository.xml
+++ b/src/main/resources/com/project/repository/LoadTestResultRepository.xml
@@ -30,8 +30,16 @@
     </insert>
 
     <update id="updateResult">
-        UPDATE load_test_result SET
-
+        UPDATE load_test_result
+        SET total_requests = #{totalRequests}
+          , success_count = #{successCount}
+          , fail_count = #{failCount}
+          , avg_latency_ms = #{avgLatencyMs}
+          , min_latency_ms = #{minLatencyMs}
+          , max_latency_ms = #{maxLatencyMs}
+          , p99_latency_ms = #{p99LatencyMs}
+          , ended_at = #{endedAt}
+        WHERE id = #{id}
     </update>
 
     <select id="selectResultByScenarioId" resultType="com.project.model.LoadTestResult">

--- a/src/test/java/com/project/service/LoadTestServiceTest.java
+++ b/src/test/java/com/project/service/LoadTestServiceTest.java
@@ -1,0 +1,306 @@
+package com.project.service;
+
+import com.project.model.LoadTestResult;
+import com.project.model.LoadTestScenario;
+import com.project.repository.LoadTestResultRepository;
+import com.project.repository.LoadTestScenarioRepository;
+import com.project.service.dto.TestStats;
+import com.project.service.runner.LoadTestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoadTestServiceTest {
+
+    @Mock
+    private LoadTestRunner loadTestRunner;
+
+    @Mock
+    private LoadTestResultRepository loadTestResultRepository;
+
+    @Mock
+    private LoadTestScenarioRepository loadTestScenarioRepository;
+
+    private LoadTestService loadTestService;
+    private Clock fixedClock;
+    private LocalDateTime fixedNow;
+
+    @BeforeEach
+    void setUp() {
+        Instant fixedInstant = Instant.parse("2026-02-17T10:15:30Z");
+        fixedClock = Clock.fixed(fixedInstant, ZoneId.of("UTC"));
+        fixedNow = LocalDateTime.now(fixedClock);
+        loadTestService = new LoadTestService(
+                loadTestRunner,
+                loadTestResultRepository,
+                loadTestScenarioRepository,
+                fixedClock
+        );
+    }
+
+    @Test
+    @DisplayName("startTestEngine: 정상 흐름에서 scenario insert -> result insert -> runner -> update 순서로 호출한다")
+    void startTestEngine_happyPath_callOrderIsCorrect() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        TestStats stats = sampleStats();
+        stubScenarioAndResultIds(10L, 20L);
+        when(loadTestRunner.run(scenario, 20L)).thenReturn(stats);
+
+        // Act
+        loadTestService.startTestEngine(scenario);
+
+        // Assert
+        InOrder inOrder = inOrder(loadTestScenarioRepository, loadTestResultRepository, loadTestRunner);
+        inOrder.verify(loadTestScenarioRepository).insertScenario(scenario);
+        inOrder.verify(loadTestResultRepository).insertResult(any(LoadTestResult.class));
+        inOrder.verify(loadTestRunner).run(scenario, 20L);
+        inOrder.verify(loadTestResultRepository).updateResult(any(LoadTestResult.class));
+    }
+
+    @Test
+    @DisplayName("startTestEngine: scenario insert로 생성된 ID를 result.scenarioId에 반영한다")
+    void startTestEngine_generatedScenarioId_isUsedForResultScenarioId() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        TestStats stats = sampleStats();
+        AtomicReference<LoadTestResult> insertedSnapshot = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            LoadTestScenario arg = invocation.getArgument(0);
+            arg.setId(101L);
+            return null;
+        }).when(loadTestScenarioRepository).insertScenario(scenario);
+
+        doAnswer(invocation -> {
+            LoadTestResult arg = invocation.getArgument(0);
+            insertedSnapshot.set(copyResult(arg));
+            arg.setId(202L);
+            return null;
+        }).when(loadTestResultRepository).insertResult(any(LoadTestResult.class));
+
+        when(loadTestRunner.run(scenario, 202L)).thenReturn(stats);
+
+        // Act
+        loadTestService.startTestEngine(scenario);
+
+        // Assert
+        assertThat(insertedSnapshot.get()).isNotNull();
+        assertThat(insertedSnapshot.get().getScenarioId()).isEqualTo(101L);
+    }
+
+    @Test
+    @DisplayName("startTestEngine: runner 결과(TestStats)를 updateResult에 그대로 반영한다")
+    void startTestEngine_runnerStats_areMappedToUpdatedResult() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        TestStats stats = new TestStats(70, 30, 100, 12.5, 3.0, 44.0, 40.0);
+        stubScenarioAndResultIds(11L, 22L);
+        when(loadTestRunner.run(scenario, 22L)).thenReturn(stats);
+
+        ArgumentCaptor<LoadTestResult> updateCaptor = ArgumentCaptor.forClass(LoadTestResult.class);
+
+        // Act
+        loadTestService.startTestEngine(scenario);
+
+        // Assert
+        verify(loadTestResultRepository).updateResult(updateCaptor.capture());
+        LoadTestResult updated = updateCaptor.getValue();
+
+        assertThat(updated.getId()).isEqualTo(22L);
+        assertThat(updated.getSuccessCount()).isEqualTo(70);
+        assertThat(updated.getFailCount()).isEqualTo(30);
+        assertThat(updated.getTotalRequests()).isEqualTo(100);
+        assertThat(updated.getAvgLatencyMs()).isEqualTo(12.5);
+        assertThat(updated.getMinLatencyMs()).isEqualTo(3.0);
+        assertThat(updated.getMaxLatencyMs()).isEqualTo(44.0);
+        assertThat(updated.getP99LatencyMs()).isEqualTo(40.0);
+    }
+
+    @Test
+    @DisplayName("startTestEngine: startedAt/endedAt은 주입된 Clock 기준으로 설정된다")
+    void startTestEngine_timeFields_areSetFromInjectedClock() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        TestStats stats = sampleStats();
+        stubScenarioAndResultIds(33L, 44L);
+        when(loadTestRunner.run(scenario, 44L)).thenReturn(stats);
+
+        ArgumentCaptor<LoadTestResult> insertCaptor = ArgumentCaptor.forClass(LoadTestResult.class);
+        ArgumentCaptor<LoadTestResult> updateCaptor = ArgumentCaptor.forClass(LoadTestResult.class);
+
+        // Act
+        loadTestService.startTestEngine(scenario);
+
+        // Assert
+        verify(loadTestResultRepository).insertResult(insertCaptor.capture());
+        verify(loadTestResultRepository).updateResult(updateCaptor.capture());
+
+        assertThat(insertCaptor.getValue().getStartedAt()).isEqualTo(fixedNow);
+        assertThat(updateCaptor.getValue().getEndedAt()).isEqualTo(fixedNow);
+    }
+
+    @Test
+    @DisplayName("startTestEngine: 통계가 0이어도 updateResult가 정상 호출된다")
+    void startTestEngine_zeroStats_updatesWithZeros() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        TestStats zeroStats = new TestStats(0, 0, 0, 0.0, 0.0, 0.0, 0.0);
+        stubScenarioAndResultIds(1L, 2L);
+        when(loadTestRunner.run(scenario, 2L)).thenReturn(zeroStats);
+
+        ArgumentCaptor<LoadTestResult> updateCaptor = ArgumentCaptor.forClass(LoadTestResult.class);
+
+        // Act
+        loadTestService.startTestEngine(scenario);
+
+        // Assert
+        verify(loadTestResultRepository).updateResult(updateCaptor.capture());
+        LoadTestResult updated = updateCaptor.getValue();
+        assertThat(updated.getTotalRequests()).isZero();
+        assertThat(updated.getSuccessCount()).isZero();
+        assertThat(updated.getFailCount()).isZero();
+        assertThat(updated.getAvgLatencyMs()).isZero();
+        assertThat(updated.getP99LatencyMs()).isZero();
+    }
+
+    @Test
+    @DisplayName("startTestEngine: scenario insert 실패 시 예외를 전파하고 나머지 의존성은 호출하지 않는다")
+    void startTestEngine_whenScenarioInsertFails_propagatesAndStops() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        RuntimeException expected = new RuntimeException("scenario insert fail");
+        doThrow(expected).when(loadTestScenarioRepository).insertScenario(scenario);
+
+        // Act
+        RuntimeException actual = assertThrows(RuntimeException.class, () -> loadTestService.startTestEngine(scenario));
+
+        // Assert
+        assertThat(actual).isSameAs(expected);
+        verifyNoInteractions(loadTestResultRepository, loadTestRunner);
+    }
+
+    @Test
+    @DisplayName("startTestEngine: result insert 실패 시 예외를 전파하고 runner/update를 호출하지 않는다")
+    void startTestEngine_whenResultInsertFails_propagatesAndSkipsRunnerAndUpdate() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        doAnswer(invocation -> {
+            LoadTestScenario arg = invocation.getArgument(0);
+            arg.setId(555L);
+            return null;
+        }).when(loadTestScenarioRepository).insertScenario(scenario);
+        doThrow(new RuntimeException("result insert fail"))
+                .when(loadTestResultRepository).insertResult(any(LoadTestResult.class));
+
+        // Act
+        assertThrows(RuntimeException.class, () -> loadTestService.startTestEngine(scenario));
+
+        // Assert
+        verify(loadTestResultRepository, never()).updateResult(any(LoadTestResult.class));
+        verifyNoInteractions(loadTestRunner);
+    }
+
+    @Test
+    @DisplayName("startTestEngine: runner 예외 시 예외를 전파하고 updateResult는 호출하지 않는다")
+    void startTestEngine_whenRunnerFails_propagatesAndSkipsUpdate() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        stubScenarioAndResultIds(77L, 88L);
+        when(loadTestRunner.run(scenario, 88L)).thenThrow(new RuntimeException("runner failed"));
+
+        // Act
+        assertThrows(RuntimeException.class, () -> loadTestService.startTestEngine(scenario));
+
+        // Assert
+        verify(loadTestResultRepository, never()).updateResult(any(LoadTestResult.class));
+    }
+
+    @Test
+    @DisplayName("startTestEngine: updateResult 실패 시 예외를 전파한다")
+    void startTestEngine_whenUpdateFails_propagatesException() {
+        // Arrange
+        LoadTestScenario scenario = sampleScenario();
+        stubScenarioAndResultIds(9L, 19L);
+        when(loadTestRunner.run(scenario, 19L)).thenReturn(sampleStats());
+        doThrow(new RuntimeException("update fail"))
+                .when(loadTestResultRepository).updateResult(any(LoadTestResult.class));
+
+        // Act
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> loadTestService.startTestEngine(scenario));
+
+        // Assert
+        assertThat(exception).hasMessage("update fail");
+        verify(loadTestRunner).run(scenario, 19L);
+    }
+
+    private void stubScenarioAndResultIds(long scenarioId, long resultId) {
+        doAnswer(invocation -> {
+            LoadTestScenario arg = invocation.getArgument(0);
+            arg.setId(scenarioId);
+            return null;
+        }).when(loadTestScenarioRepository).insertScenario(any(LoadTestScenario.class));
+
+        doAnswer(invocation -> {
+            LoadTestResult arg = invocation.getArgument(0);
+            arg.setId(resultId);
+            return null;
+        }).when(loadTestResultRepository).insertResult(any(LoadTestResult.class));
+    }
+
+    private LoadTestScenario sampleScenario() {
+        LoadTestScenario scenario = new LoadTestScenario();
+        scenario.setName("unit-test-scenario");
+        scenario.setTargetUrl("http://localhost:8080/test");
+        scenario.setHttpMethod("GET");
+        scenario.setRequestParams("{}");
+        scenario.setTargetTps(100);
+        scenario.setVirtualThreadCount(10);
+        scenario.setDurationSeconds(5);
+        return scenario;
+    }
+
+    private TestStats sampleStats() {
+        return new TestStats(90, 10, 100, 11.0, 2.0, 41.0, 39.0);
+    }
+
+    private LoadTestResult copyResult(LoadTestResult source) {
+        LoadTestResult copied = new LoadTestResult();
+        copied.setId(source.getId());
+        copied.setScenarioId(source.getScenarioId());
+        copied.setTotalRequests(source.getTotalRequests());
+        copied.setSuccessCount(source.getSuccessCount());
+        copied.setFailCount(source.getFailCount());
+        copied.setAvgLatencyMs(source.getAvgLatencyMs());
+        copied.setMinLatencyMs(source.getMinLatencyMs());
+        copied.setMaxLatencyMs(source.getMaxLatencyMs());
+        copied.setP99LatencyMs(source.getP99LatencyMs());
+        copied.setStartedAt(source.getStartedAt());
+        copied.setEndedAt(source.getEndedAt());
+        return copied;
+    }
+}


### PR DESCRIPTION
 ## 개요

#2 
Virtual Thread 기반 HTTP 클라이언트 설계
--

  Virtual Thread 기반으로 부하 테스트를 실행하고, 요청 결과를 집계해 DB에 저장하는 기능을 새로 구현했습니다.
  테스트 종료 시 성공/실패 건수와 지연시간 지표(avg/min/max/p99)를 함께 업데이트하며, 핵심 오케스트레이션 로직에 대한 단위 테스트도 추가했습니다.

  ## 구현 내용

  - Load Test 실행 엔진 구현
      - 시나리오 저장 -> 결과 row 생성 -> 부하 실행 -> 최종 집계 업데이트 흐름 구현
  - Virtual Thread 기반 요청 처리
      - 다중 worker가 테스트 종료 시각까지 요청 반복 수행
  - HTTP 호출 및 실패 로그 저장 구현
      - 요청 실패 시 load_test_fail_log에 상세 정보 저장
  - 성능 지표 집계 구현
      - success/fail/totalRequests
      - avgLatencyMs/minLatencyMs/maxLatencyMs/p99LatencyMs
  - 결과 업데이트 SQL 구현
      - LoadTestResultRepository.xml의 updateResult SQL 완성
  - 시간 의존성 제어 추가
      - Clock 주입 + LocalDateTime.now(clock) 사용
      - ClockConfig로 기본 시스템 시간 빈 등록
  - 단위 테스트 추가 (JUnit 5 + Mockito)
      - LoadTestServiceTest 신규 작성
      - 정상/예외/경계 포함 9개 케이스 검증

  ## 테스트

  - 실행 명령:
      - .\gradlew.bat test --tests com.project.service.LoadTestServiceTest
  - 결과:
      - BUILD SUCCESSFUL